### PR TITLE
Fix article number parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,7 +101,7 @@ def normalizar_articulo(num_str: Optional[str]) -> str:
         return WORDS_TO_INT[s]
     if s in ROMAN_TO_INT:
         return str(ROMAN_TO_INT[s])
-    nums = re.findall(r"(\d+)([a-z]*)", s)
+    nums = re.findall(r"(\d+)\s*([a-z]*)", s)
     comps = [n + t for n, t in nums]
     return "".join(comps) or s
 


### PR DESCRIPTION
## Summary
- fix normalizar_articulo to correctly parse numbers with spaces like `1 bis`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_683fb57d530c8331984a86e9c12258b1