### PR TITLE
Improve README and start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ Esta API permite consultar leyes chilenas por su número, y acceder a sus artíc
 
 ```bash
 pip install -r requirements.txt
+```
+
+## 🚀 Ejecución
+
+Para iniciar el servidor en modo local utiliza:
+
+```bash
+uvicorn main:app --reload
+```
+
+Luego visita `http://localhost:8000/docs` para ver la documentación interactiva.

--- a/main.py
+++ b/main.py
@@ -283,3 +283,9 @@ async def consultar_articulo_html(
 @app.get("/health", summary="Estado del servicio")
 def health():
     return {"status": "ok"}
+
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.getenv("PORT", 8000))
+    uvicorn.run("main:app", host="0.0.0.0", port=port)
+


### PR DESCRIPTION
## Summary
- add README instructions for running the server
- add `__main__` entry point to run the API with `uvicorn`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc6e30ef083318a8c982c16b6fb37