### PR TITLE
Add endpoint tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ uvicorn
 requests
 beautifulsoup4
 lxml
-httpx
+httpx<0.28
 cachetools

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,33 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_ley_articulo():
+    params = {"numero_ley": "21595", "articulo": "1"}
+    response = client.get("/ley", params=params)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ley"] == "21595"
+    assert data["articulos_totales_en_respuesta"] == 1
+    assert len(data["articulos"]) == 1
+    assert data["articulos"][0]["texto"]
+
+
+def test_ley_html():
+    params = {"id_norma": "1195119", "id_parte": "10449614"}
+    response = client.get("/ley_html", params=params)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["idNorma"] == "1195119"
+    assert data["idParte"] == "10449614"
+    assert data["texto_html_extraido"]


### PR DESCRIPTION
## Summary
- add `httpx` version pin for Starlette test client compatibility
- add integration tests for `/health`, `/ley`, and `/ley_html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb6ea4d90833195150e72128076aa