### PR TITLE
Add HEAD support for root endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -186,6 +186,15 @@ def extraer_articulos(xml_data: bytes) -> List[Articulo]:
 
 # --- Endpoints ---
 
+@app.api_route("/", methods=["GET", "HEAD"], summary="Información básica")
+async def index() -> dict:
+    """Endpoint raíz simple para indicar que el servicio funciona."""
+    return {
+        "mensaje": "API de Consulta de Leyes Chilenas",
+        "version": app.version,
+        "documentacion": app.docs_url,
+    }
+
 @app.get("/ley", response_model=LeyDetalle, summary="Consultar ley (XML)")
 async def consultar_ley(
     numero_ley: Optional[str] = Query(

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -6,6 +6,16 @@ from main import app
 client = TestClient(app)
 
 
+def test_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data.get("documentacion") == app.docs_url
+    assert "mensaje" in data
+    assert "version" in data
+    head = client.head("/")
+    assert head.status_code == 200
+
 def test_health():
     response = client.get("/health")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- serve root path with both GET and HEAD
- use `app.docs_url` for docs path
- check docs URL and HEAD behavior in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c3e289ac83319f43afb647b1216e