### PR TITLE
Fix retry logic in obtener_id_norma

### DIFF
--- a/main.py
+++ b/main.py
@@ -141,7 +141,6 @@ async def obtener_id_norma(n_ley: str, client: httpx.AsyncClient) -> Optional[st
                     if idn:
                         cache_id_norma[clave] = idn
                         return idn
-            return None
         except Exception:
             await asyncio.sleep(1)
     return None


### PR DESCRIPTION
## Summary
- ensure `obtener_id_norma` retries all attempts instead of returning early

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68653c1907088331a916f36732e511c1